### PR TITLE
fix:ログイン後の診断結果を修正

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -30,6 +30,8 @@ class QuestionsController < ApplicationController
     end
 
     @cold_symptom = ColdSymptom.find_by(symptom_type: @diagnosis)
+    reset_answers_and_clear_user_data(current_user)
+
     unless @cold_symptom
       redirect_to root_path, alert: '診断結果が見つかりません。最初からやり直してください。'
     end
@@ -45,5 +47,10 @@ class QuestionsController < ApplicationController
     answers.each do |question_id, choice_id|
       Answer.create(user_id: user.id, question_id: question_id, choice_id: choice_id)
     end
+  end
+
+  def reset_answers_and_clear_user_data(user)
+    user.answers.destroy_all if user # ログインユーザーの回答を削除
+    session.delete(:answers)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,11 +36,14 @@ class User < ApplicationRecord
 
   def self.diagnose_from_choice_ids(choice_ids)
     choices = Choice.where(id: choice_ids).pluck(:id, :question_type, :question_body)
+    puts "Choices: #{choices.inspect}"
 
     a_count = choices.count { |choice| choice[1] == "A" }
     b_count = choices.count { |choice| choice[1] == "B" }
     c_count = choices.count { |choice| choice[1] == "C" }
     d_count = choices.count { |choice| choice[2] == "36.2℃以下" }
+
+    puts "A Count: #{a_count}, B Count: #{b_count}, C Count: #{c_count}, D Count: #{d_count}"
 
     if a_count > b_count && a_count > c_count && d_count > 0
       ColdSymptom.symptom_types[:systemic]


### PR DESCRIPTION
- ログイン後のデータに重複が見られたので、セッションのリセット及び過去の回答データを削除して、診断タイプだけを保存する構成に変更した。