### PR TITLE
GitHubActionにおけるCapybara実行時のエラーについて

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: Run rspec, rubocop
 
 on:
   push:
-  pull_request:
 
 env:
   RENDER_DB_URL: ${{secrets.RENDER_DB_URL}}
@@ -19,6 +18,10 @@ jobs:
         image: postgres
         ports:
           - 5432:5432
+      chrome:
+        image: seleniarm/standalone-chromium:latest
+        ports:
+          - 4444:4444
 
     steps:
       - name: Checkout code
@@ -28,6 +31,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+
+      - name: Set up Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 120
+          install-dependencies: true
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -45,6 +54,17 @@ jobs:
       - name: Yarn install
         run: yarn install --check-files
 
+      - name: Check for port conflicts and set CAPYBARA_PORT
+        run: |
+          PORT=4444
+          if lsof -i:$PORT; then
+            echo "Port $PORT is in use, killing the process"
+            lsof -ti:$PORT | xargs kill -9
+          fi
+          CAPYBARA_PORT=3001
+          echo "CAPYBARA_PORT=$CAPYBARA_PORT" >> $GITHUB_ENV
+          echo "DEBUG: Capybara port set to $CAPYBARA_PORT"
+
       - name: Database create and migrate
         run: |
           cp config/database.yml.ci config/database.yml
@@ -54,8 +74,13 @@ jobs:
       - name: assets precompile
         run: bundle exec rake assets:precompile RAILS_ENV=test
 
-      - name: Run rspec
-        run: bundle exec rspec
+      - name: Run tests
+        run: |
+          echo "DEBUG: Running tests with SELENIUM_DRIVER_URL=$SELENIUM_DRIVER_URL and CAPYBARA_PORT=$CAPYBARA_PORT"
+          bundle exec rspec
+        env:
+          SELENIUM_DRIVER_URL: http://localhost:4444/wd/hub
+          CAPYBARA_PORT: ${{ env.CAPYBARA_PORT }}
 
   rubocop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- 解決したいもの(なるべく小さい粒度で記載してください)
　現在、本リリースに向けてGit Hub Actionsを実装しているところ、Rspec（Capybara）実行時に、`Address already in use - bind(2) for "10.1.0.91" port 4444 (Errno::EADDRINUSE)`とエラーが表示されており、VSコード上でコマンドを指示した際に成功するテストが、Git Hub Actions上で失敗すること。
（以下に、関係するコードを記載させていただきます。）

.github/workflows/main.yml（本draft pull request分を追記）
```
name: Run rspec, rubocop

on:
  push:

env:
  RENDER_DB_URL: ${{secrets.RENDER_DB_URL}}

jobs:
  rspec:
    runs-on: ubuntu-latest
    timeout-minutes: 10
    services:
      postgres:
        env:
          POSTGRES_PASSWORD: password
          POSTGRES_DB: test
        image: postgres
        ports:
          - 5432:5432
      chrome:　　＃今回追加分
        image: seleniarm/standalone-chromium:latest
        ports:
          - 4444:4444

    steps:
      - name: Checkout code
        uses: actions/checkout@v2

      - name: Set up Ruby
        uses: ruby/setup-ruby@v1
        with:
          bundler-cache: true

      - name: Set up Chrome　＃今回追加分
        uses: browser-actions/setup-chrome@v1
        with:
          chrome-version: 120
          install-dependencies: true

      - name: Cache node modules
        uses: actions/cache@v2
        with:
          path: node_modules
          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
          restore-keys: |
            ${{ runner.os }}-node-

      - name: Bundler and gem install
        run: |
          gem install bundler
          bundle install --jobs 4 --retry 3 --path vendor/bundle

      - name: Yarn install
        run: yarn install --check-files

      - name: Check for port conflicts and set CAPYBARA_PORT　＃今回追加分（ポートの競合を解消）
        run: |
          PORT=4444
          if lsof -i:$PORT; then
            echo "Port $PORT is in use, killing the process"
            lsof -ti:$PORT | xargs kill -9
          fi
          CAPYBARA_PORT=3001
          echo "CAPYBARA_PORT=$CAPYBARA_PORT" >> $GITHUB_ENV
          echo "DEBUG: Capybara port set to $CAPYBARA_PORT"

      - name: Database create and migrate
        run: |
          cp config/database.yml.ci config/database.yml
          bundle exec rails db:create RAILS_ENV=test
          bundle exec rails db:migrate RAILS_ENV=test

      - name: assets precompile
        run: bundle exec rake assets:precompile RAILS_ENV=test

      - name: Run tests　＃今回追加分（Capybaraで使用しているportが、競合している4444ではないかを確認）
        run: |
          echo "DEBUG: Running tests with SELENIUM_DRIVER_URL=$SELENIUM_DRIVER_URL and CAPYBARA_PORT=$CAPYBARA_PORT"
          bundle exec rspec
        env:
          SELENIUM_DRIVER_URL: http://localhost:4444/wd/hub
          CAPYBARA_PORT: ${{ env.CAPYBARA_PORT }}

  rubocop:
    runs-on: ubuntu-latest
    timeout-minutes: 10
    steps:
      - name: Checkout code
        uses: actions/checkout@v2

      - name: Set up Ruby
        uses: ruby/setup-ruby@v1
        with:
          bundler-cache: true

      - name: Run rubocop
        run: bundle exec rubocop
```
/Users/fuwayuri/portfolio_2/spec/support/capybara.rb
```
require 'capybara/rspec'
require 'selenium/webdriver'

Capybara.register_driver :remote_chrome do |app|
  options = Selenium::WebDriver::Chrome::Options.new
  options.add_argument('no-sandbox')
  options.add_argument('headless')
  options.add_argument('disable-gpu')
  options.add_argument('window-size=1680,1050')

  driver_url = ENV['SELENIUM_DRIVER_URL'] || 'http://localhost:4444/wd/hub'
  puts "DEBUG: Using Selenium driver URL: #{driver_url}"

  Capybara::Selenium::Driver.new(app, browser: :remote, url: driver_url, capabilities: options)
end
```

/Users/fuwayuri/portfolio_2/spec/rails_helper.rb　（本エラーと関連部分のみ抜粋）
```
  config.before(:each, type: :system) do
    driven_by :remote_chrome
    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
    Capybara.server_port = 4444
    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
    Capybara.ignore_hidden_elements = false
  end
```

/Users/fuwayuri/portfolio_2/compose.yml
```
version: '3'
services:
  db:
    image: postgres
    restart: always
    environment:
      TZ: Asia/Tokyo
      POSTGRES_PASSWORD: password
    volumes:
      - postgresql_data:/var/lib/postgresql
    ports:
      - 5432:5432
  web:
    build:
      context: .
      dockerfile: Dockerfile.dev
    command: bash -c "bundle install && bundle exec rails db:prepare && rm -f tmp/pids/server.pid && ./bin/dev"
    tty: true
    stdin_open: true
    volumes:
      - .:/myapp
      - bundle_data:/usr/local/bundle:cached
      - node_modules:/app/node_modules
    environment:
      TZ: Asia/Tokyo
      SELENIUM_DRIVER_URL: http://chrome:4444/wd/hub
    ports:
      - "3000:3000"
    depends_on:
      - db
      - chrome
  chrome:
    image: seleniarm/standalone-chromium:latest
    shm_size: 1g
    ports:
      - 4444:4444
volumes:
  bundle_data:
  postgresql_data:
  node_modules:
```

/Users/fuwayuri/portfolio_2/config/database.yml（本エラーと関連部分のみ抜粋）
```
default: &default
  adapter: postgresql
  encoding: unicode
  # For details on connection pooling, see Rails configuration guide
  # https://guides.rubyonrails.org/configuring.html#database-pooling
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  host: db
  username: postgres
  password: password
  test:
  <<: *default
  database: myapp_test
```

/Users/fuwayuri/portfolio_2/config/database.yml.ci
```
test:
  adapter: postgresql
  encoding: unicode
  username: postgres
  password: password
  host: localhost
  database: myapp_test
```

- Git Hub Action実行時におけるRspecエラー文（抜粋）

```
/home/runner/work/portfolio_2/portfolio_2/vendor/bundle/ruby/3.2.0/gems/puma-6.4.2/lib/puma/binder.rb:334:in 
`initialize': Address already in use - bind(2) for "10.1.0.91" port 4444 (Errno::EADDRINUSE)
```

- エラーの意味とエラー内容から推測される原因
ChatGPTより参照
> ポート4444が既に他のプロセスによって使用されているため、Pumaがそのポートにバインドできないことを示しています。

- 実装する際に参考にした資料
　Git Hub Actionを記載する際に、Git公式ドキュメント「[GitHub Actions を理解する](https://docs.github.com/ja/actions/learn-github-actions/understanding-github-actions)」や既にアプリを作成された方のGit Hub Actionで自動テストを実行している方の書き方を参照しました。また、本アプリではCapybara実行に当たり、chromeの環境を使用しているため、Google Chrome/Chromiumをセットするための[setup-chrome](https://github.com/browser-actions/setup-chrome)を参照してGit Hub Actionを作成しています。
　
- エラーを解決するために調べた資料
　全く同じエラーが発生している記事については、[CircleCIのシステムスペックをselenium dockerを利用する](https://qiita.com/tomoronn3/items/ee66d4bdcf1f21a352c2)が見つかりましたが、記載内容は、既に自身が実装した内容であったため、参考になりませんでした。また、本エラーの課題となっている4444のポート番号の競合を避けるため、本Draft Pull Requestの通りCapybaraを別ポートに指定をして、テスト実行時のデバッグログ上でポートの変更が出来ていることを確認しましたが、エラーの解消には至りませんでした。
　デバッグログを出している、Git Hub Action上のコード
```
      - name: Run tests　＃今回追加分（Capybaraで使用しているportが、競合している4444ではないかを確認）
        run: |
          echo "DEBUG: Running tests with SELENIUM_DRIVER_URL=$SELENIUM_DRIVER_URL and CAPYBARA_PORT=$CAPYBARA_PORT"
```
　デバッグログ
`DEBUG: Running tests with SELENIUM_DRIVER_URL=http://localhost:4444/wd/hub and CAPYBARA_PORT=3001`