### PR TITLE
fix:Diaryのテスト修正#220

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,14 +71,6 @@ RSpec.configure do |config|
     Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
     Capybara.server_port = 4444
     Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
-    puts "DEBUG: Capybara server_host: #{Capybara.server_host}, server_port: #{Capybara.server_port}, app_host: #{Capybara.app_host}"
     Capybara.ignore_hidden_elements = false
-  end
-
-  config.after(:each, type: :system) do
-    puts "DEBUG: Checking port 4444 usage"
-    system('lsof -i :4444 || echo "Port 4444 is not in use"')
-    puts "DEBUG: Checking port 3001 usage"
-    system('lsof -i :3001 || echo "Port 3001 is not in use"')
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -9,7 +9,6 @@ Capybara.register_driver :remote_chrome do |app|
   options.add_argument('window-size=1680,1050')
 
   driver_url = ENV['SELENIUM_DRIVER_URL'] || 'http://localhost:4444/wd/hub'
-  puts "DEBUG: Using Selenium driver URL: #{driver_url}"
 
   Capybara::Selenium::Driver.new(app, browser: :remote, url: driver_url, capabilities: options)
 end

--- a/spec/system/diary_spec.rb
+++ b/spec/system/diary_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Diaries', type: :system do
       end
       it '本日の記録は既に作成されていると表示される' do
         find('.navbar .nav-link', text: '分析').click
+        expect(page).to have_content '本日の記録を作成しました'
         expect(page).to have_content '本日の記録は既に作成されています'
         expect(current_path).to eq diaries_path
       end


### PR DESCRIPTION
- Diaryのテストにおいて、JavaScriptの影響で失敗する部分があったため、遷移後の画面にあるべき要素を確認する処理を入れて、待機時間を持たせることで解消した。