### PR TITLE
fix:DiarySpecの修正#222

### DIFF
--- a/spec/system/diary_spec.rb
+++ b/spec/system/diary_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Diaries', type: :system do
       end
       it '本日の記録は既に作成されていると表示される' do
         find('.navbar .nav-link', text: '分析').click
+        expect(page).to have_content '本日の記録を作成しました'
         expect(page).to have_content '本日の記録は既に作成されています'
         expect(current_path).to eq diaries_path
       end


### PR DESCRIPTION
- Diaryのテストにおいて、JavaScriptの影響で失敗する部分があったため、遷移後の画面にあるべき要素を確認する処理を入れて、待機時間を持たせることで解消した。